### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ version = "0.1.0"
 
 [[package]]
 name = "marco-test-one"
-version = "0.1.5"
+version = "0.1.6"
 
 [[package]]
 name = "marco-test-three"
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "marco-test-four"
+version = "0.1.0"
+
+[[package]]
 name = "marco-test-one"
 version = "0.1.5"
 

--- a/crates/marco-test-four/CHANGELOG.md
+++ b/crates/marco-test-four/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-four-v0.1.0...marco-test-four-v0.1.0) - 2023-01-11
+
+### Other
+- some changes

--- a/crates/marco-test-four/Cargo.toml
+++ b/crates/marco-test-four/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "marco-test-four"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/marco-test-four/src/main.rs
+++ b/crates/marco-test-four/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crates/marco-test-one/CHANGELOG.md
+++ b/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.1.5...marco-test-one-v0.1.6) - 2023-01-11
+
+### Other
+- some changes
+
 ## [0.1.5](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.1.4...marco-test-one-v0.1.5) - 2023-01-08
 
 ### Added

--- a/crates/marco-test-one/Cargo.toml
+++ b/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-one/src/main.rs
+++ b/crates/marco-test-one/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("Hello, world");
 }

--- a/crates/marco-test-two/CHANGELOG.md
+++ b/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.1.9...marco-test-two-v0.1.10) - 2023-01-11
+
+### Other
+- updated the following local packages: marco-test-one
+
 ## [0.1.9](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.1.8...marco-test-two-v0.1.9) - 2023-01-08
 
 ### Other

--- a/crates/marco-test-two/Cargo.toml
+++ b/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "just a test"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tokio = "1.16"
-marco-test-one = {path = "../marco-test-one", version = "0.1.5" }
+marco-test-one = {path = "../marco-test-one", version = "0.1.6" }


### PR DESCRIPTION
## 🤖 New release
* `marco-test-four`: 0.1.0 -> 0.1.0
* `marco-test-one`: 0.1.5 -> 0.1.6
* `marco-test-two`: 0.1.9 -> 0.1.10
---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).