### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-one"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
 ]
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/crates/marco-test-one/CHANGELOG.md
+++ b/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.1.8...marco-test-one-v0.1.9) - 2023-01-17
+
+### Other
+- Update main.rs
+
 ## [0.1.8](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.1.7...marco-test-one-v0.1.8) - 2023-01-14
 
 ### Other

--- a/crates/marco-test-one/Cargo.toml
+++ b/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-two/CHANGELOG.md
+++ b/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.1.12...marco-test-two-v0.1.13) - 2023-01-17
+
+### Other
+- updated the following local packages: marco-test-one
+
 ## [0.1.12](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.1.11...marco-test-two-v0.1.12) - 2023-01-14
 
 ### Other

--- a/crates/marco-test-two/Cargo.toml
+++ b/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "just a test"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tokio = "1.16"
-marco-test-one = {path = "../marco-test-one", version = "0.1.8" }
+marco-test-one = {path = "../marco-test-one", version = "0.1.9" }


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.1.8 -> 0.1.9
* `marco-test-two`: 0.1.12 -> 0.1.13
---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).