### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-one"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "serde",
 ]
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/crates/marco-test-one/CHANGELOG.md
+++ b/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.1.10...marco-test-one-v0.1.11) - 2023-01-24
+
+### Other
+- wip
+
 ## [0.1.10](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.1.9...marco-test-one-v0.1.10) - 2023-01-18
 
 ### Other

--- a/crates/marco-test-one/Cargo.toml
+++ b/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-two/CHANGELOG.md
+++ b/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.1.14...marco-test-two-v0.1.15) - 2023-01-24
+
+### Other
+- updated the following local packages: marco-test-one
+
 ## [0.1.14](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.1.13...marco-test-two-v0.1.14) - 2023-01-18
 
 ### Other

--- a/crates/marco-test-two/Cargo.toml
+++ b/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 description = "just a test"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tokio = "1.16"
-marco-test-one = {path = "../marco-test-one", version = "0.1.10" }
+marco-test-one = {path = "../marco-test-one", version = "0.1.11" }


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.1.10 -> 0.1.11
* `marco-test-two`: 0.1.14 -> 0.1.15
---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).