### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-one"
-version = "0.1.19"
+version = "0.1.20"
 
 [[package]]
 name = "marco-test-three"
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.1.24"
+version = "0.2.0"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/crates/marco-test-one/CHANGELOG.md
+++ b/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.1.19...marco-test-one-v0.1.20) - 2023-02-25
+
+### Other
+- wip
+
 ## [0.1.19](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.1.18...marco-test-one-v0.1.19) - 2023-02-20
 
 ### Other

--- a/crates/marco-test-one/Cargo.toml
+++ b/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-one/src/lib.rs
+++ b/crates/marco-test-one/src/lib.rs
@@ -1,3 +1,7 @@
+pub fn hi() {
+    println!("Hi, world!");
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/marco-test-two/CHANGELOG.md
+++ b/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.1.24...marco-test-two-v0.2.0) - 2023-02-25
+
+### Other
+- break
+
 ## [0.1.24](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.1.23...marco-test-two-v0.1.24) - 2023-02-25
 
 ### Other

--- a/crates/marco-test-two/Cargo.toml
+++ b/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.1.24"
+version = "0.2.0"
 edition = "2021"
 description = "just a test"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tokio = "1.16"
-marco-test-one = {path = "../marco-test-one", version = "0.1.19" }
+marco-test-one = {path = "../marco-test-one", version = "0.1.20" }

--- a/crates/marco-test-two/src/lib.rs
+++ b/crates/marco-test-two/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn hello() {
+pub fn hellooo() {
     println!("Hello, world!");
 }
 


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.1.19 -> 0.1.20 (✓ semver check passed)
* `marco-test-two`: 0.1.24 -> 0.2.0 (⚠️ breaking)

### ⚠️ marco-test-two breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.18.3/src/lints/function_missing.ron

Failed in:
  function marco_test_two::hello, previously in file /private/var/folders/n1/c6p1r6x10vz3wx7qpzrs8l780000gn/T/.tmp1qOLli/marco-test-two/src/lib.rs:1
```

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).