### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.2.2...marco-test-one-v0.2.3) - 2023-04-16
+
+### Other
+- Update main.rs
+
 ## [0.2.1](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.2.0...marco-test-one-v0.2.1) - 2023-04-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -184,7 +184,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -201,9 +201,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.12"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
+checksum = "3b32c5ea3aabaf4deb5f5ced2d688ec0844c881c9e6c696a8b769a05fc691e62"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -584,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
 dependencies = [
  "bytes",
  "fnv",
@@ -658,9 +658,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-one"
-version = "0.2.2"
+version = "0.2.3"
 
 [[package]]
 name = "marco-test-three"
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "marco-test-one",
  "tokio",
@@ -1035,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1045,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1260,29 +1260,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1359,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.13"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1435,7 +1435,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 
 
 [workspace.dependencies]

--- a/crates/marco-test-two/CHANGELOG.md
+++ b/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.1...marco-test-two-v0.4.2) - 2023-04-16
+
+### Other
+- updated the following local packages: marco-test-one
+
 ## [0.4.1](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.0...marco-test-two-v0.4.1) - 2023-04-10
 
 ### Other

--- a/crates/marco-test-two/Cargo.toml
+++ b/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "just a test"
 license = "MIT OR Apache-2.0"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,21 +1,13 @@
 [workspace]
-update_dependencies = true
-update_changelog = false
+dependencies_update = true
+changelog_update = false
 
-[workspace.release]
-no_verify = true
-allow_dirty = false
-
-[workspace.git_release]
-enable = true
-
-[package.marco-test-one]
+[[package]]
+name = "marco-test-one"
 semver_check = "no"
-update_changelog = true
+changelog_update = true
 changelog_path = "./CHANGELOG.md"
 
-[package.marco-test-two]
-update_changelog = true
-
-[package.marco-test-two.git_release]
-enable = false
+[[package]]
+name = "marco-test-two"
+changelog_update = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,7 +4,7 @@ changelog_update = false
 
 [[package]]
 name = "marco-test-one"
-semver_check = "no"
+semver_check = false
 changelog_update = true
 changelog_path = "./CHANGELOG.md"
 


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.2.2 -> 0.2.3
* `marco-test-two`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `marco-test-one`
<blockquote>

## [0.2.3](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.2.2...marco-test-one-v0.2.3) - 2023-04-16

### Other
- Update main.rs
</blockquote>

## `marco-test-two`
<blockquote>

## [0.4.2](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.1...marco-test-two-v0.4.2) - 2023-04-16

### Other
- updated the following local packages: marco-test-one
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).