### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,11 +827,11 @@ dependencies = [
 
 [[package]]
 name = "marco-test-one"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "marco-test-three"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "lapin",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/crates/marco-test-one/CHANGELOG.md
+++ b/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.0...marco-test-one-v0.3.1) - 2023-05-22
+
+### Other
+- Update main.rs (#163)
+
 ## [0.3.0](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.2.6...marco-test-one-v0.3.0) - 2023-05-10
 
 ### Added

--- a/crates/marco-test-one/Cargo.toml
+++ b/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-three/CHANGELOG.md
+++ b/crates/marco-test-three/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-three-v0.1.12...marco-test-three-v0.1.13) - 2023-05-22
+
+### Other
+- update dependencies
+
 ## [0.1.12](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-three-v0.1.11...marco-test-three-v0.1.12) - 2023-05-10
 
 ### Added

--- a/crates/marco-test-three/Cargo.toml
+++ b/crates/marco-test-three/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-three"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "marco-test-three"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-two/CHANGELOG.md
+++ b/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.6...marco-test-two-v0.4.7) - 2023-05-22
+
+### Other
+- Bump tokio from 1.28.0 to 1.28.1 (#160)
+
 ## [0.4.6](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.5...marco-test-two-v0.4.6) - 2023-05-10
 
 ### Other

--- a/crates/marco-test-two/Cargo.toml
+++ b/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "just a test for release-plz"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tokio = "1.28"
-marco-test-one = {path = "../marco-test-one", version = "0.3.0" }
+marco-test-one = {path = "../marco-test-one", version = "0.3.1" }


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `marco-test-three`: 0.1.12 -> 0.1.13
* `marco-test-two`: 0.4.6 -> 0.4.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `marco-test-one`
<blockquote>

## [0.3.1](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.0...marco-test-one-v0.3.1) - 2023-05-22

### Other
- Update main.rs (#163)
</blockquote>

## `marco-test-three`
<blockquote>

## [0.1.13](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-three-v0.1.12...marco-test-three-v0.1.13) - 2023-05-22

### Other
- update dependencies
</blockquote>

## `marco-test-two`
<blockquote>

## [0.4.7](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.6...marco-test-two-v0.4.7) - 2023-05-22

### Other
- Bump tokio from 1.28.0 to 1.28.1 (#160)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).