### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,11 +842,11 @@ dependencies = [
 
 [[package]]
 name = "marco-test-one"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "marco-test-three"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "lapin",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/crates/marco-test-one/CHANGELOG.md
+++ b/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.2...marco-test-one-v0.3.3) - 2023-10-30
+
+### Other
+- wippppp
+
 ## [0.3.2](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.1...marco-test-one-v0.3.2) - 2023-07-25
 
 ### Other

--- a/crates/marco-test-one/Cargo.toml
+++ b/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-three/CHANGELOG.md
+++ b/crates/marco-test-three/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-three-v0.1.14...marco-test-three-v0.1.15) - 2023-10-30
+
+### Other
+- Bump tonic from 0.9.2 to 0.10.2 ([#175](https://github.com/MarcoIeni/rust-workspace-example/pull/175))
+- Bump anyhow from 1.0.72 to 1.0.75 ([#171](https://github.com/MarcoIeni/rust-workspace-example/pull/171))
+- Bump anyhow from 1.0.71 to 1.0.72 ([#168](https://github.com/MarcoIeni/rust-workspace-example/pull/168))
+
 ## [0.1.14](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-three-v0.1.13...marco-test-three-v0.1.14) - 2023-07-25
 
 ### Other

--- a/crates/marco-test-three/Cargo.toml
+++ b/crates/marco-test-three/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-three"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 description = "marco-test-three"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-two/CHANGELOG.md
+++ b/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.8...marco-test-two-v0.4.9) - 2023-10-30
+
+### Other
+- Bump tokio from 1.28.2 to 1.29.1 ([#167](https://github.com/MarcoIeni/rust-workspace-example/pull/167))
+- wippppp
+
 ## [0.4.8](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.7...marco-test-two-v0.4.8) - 2023-07-25
 
 ### Other

--- a/crates/marco-test-two/Cargo.toml
+++ b/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 description = "just a test for release-plz"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tokio = "1.29"
-marco-test-one = {path = "../marco-test-one", version = "0.3.2" }
+marco-test-one = {path = "../marco-test-one", version = "0.3.3" }


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `marco-test-three`: 0.1.14 -> 0.1.15
* `marco-test-two`: 0.4.8 -> 0.4.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `marco-test-one`
<blockquote>

## [0.3.3](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.2...marco-test-one-v0.3.3) - 2023-10-30

### Other
- wippppp
</blockquote>

## `marco-test-three`
<blockquote>

## [0.1.15](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-three-v0.1.14...marco-test-three-v0.1.15) - 2023-10-30

### Other
- Bump tonic from 0.9.2 to 0.10.2 ([#175](https://github.com/MarcoIeni/rust-workspace-example/pull/175))
- Bump anyhow from 1.0.72 to 1.0.75 ([#171](https://github.com/MarcoIeni/rust-workspace-example/pull/171))
- Bump anyhow from 1.0.71 to 1.0.72 ([#168](https://github.com/MarcoIeni/rust-workspace-example/pull/168))
</blockquote>

## `marco-test-two`
<blockquote>

## [0.4.9](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.8...marco-test-two-v0.4.9) - 2023-10-30

### Other
- Bump tokio from 1.28.2 to 1.29.1 ([#167](https://github.com/MarcoIeni/rust-workspace-example/pull/167))
- wippppp
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).