### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "marco-test-one"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "marco-test-three"
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/crates/marco-test-one/CHANGELOG.md
+++ b/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.3...marco-test-one-v0.3.4) - 2024-01-23
+
+### Other
+- marco-test-one change
+
 ## [0.3.3](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.2...marco-test-one-v0.3.3) - 2024-01-17
 
 ### Other

--- a/crates/marco-test-one/Cargo.toml
+++ b/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/crates/marco-test-two/CHANGELOG.md
+++ b/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.10](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.9...marco-test-two-v0.4.10) - 2024-01-23
+
+### Other
+- marco-test-one change
+
 ## [0.4.9](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.8...marco-test-two-v0.4.9) - 2024-01-17
 
 ### Other

--- a/crates/marco-test-two/Cargo.toml
+++ b/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 description = "just a test for release-plz"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tokio = "1.35"
-marco-test-one = {path = "../marco-test-one", version = "0.3.2" }
+marco-test-one = {path = "../marco-test-one", version = "0.3.4" }


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `marco-test-two`: 0.4.9 -> 0.4.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `marco-test-one`
<blockquote>

## [0.3.4](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.3...marco-test-one-v0.3.4) - 2024-01-23

### Other
- marco-test-one change
</blockquote>

## `marco-test-two`
<blockquote>

## [0.4.10](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.9...marco-test-two-v0.4.10) - 2024-01-23

### Other
- marco-test-one change
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).