### PR TITLE
chore: release

### DIFF
--- a/subdir/Cargo.lock
+++ b/subdir/Cargo.lock
@@ -932,7 +932,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "marco-test-one"
-version = "0.3.6"
+version = "0.3.7"
 
 [[package]]
 name = "marco-test-three"
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/subdir/crates/marco-test-one/CHANGELOG.md
+++ b/subdir/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.6...marco-test-one-v0.3.7) - 2024-04-21
+
+### Other
+- hi world
+
 ## [0.3.6](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.5...marco-test-one-v0.3.6) - 2024-03-10
 
 ### Other

--- a/subdir/crates/marco-test-one/Cargo.toml
+++ b/subdir/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/subdir/crates/marco-test-two/CHANGELOG.md
+++ b/subdir/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.14](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.13...marco-test-two-v0.4.14) - 2024-04-21
+
+### Other
+- hi world
+
 ## [0.4.13](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.12...marco-test-two-v0.4.13) - 2024-04-15
 
 ### Other

--- a/subdir/crates/marco-test-two/Cargo.toml
+++ b/subdir/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "just a test for release-plz"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tokio = "1.35"
-marco-test-one = {path = "../marco-test-one", version = "0.3.6" }
+marco-test-one = {path = "../marco-test-one", version = "0.3.7" }


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.3.6 -> 0.3.7
* `marco-test-two`: 0.4.13 -> 0.4.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `marco-test-one`
<blockquote>

## [0.3.7](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.6...marco-test-one-v0.3.7) - 2024-04-21

### Other
- hi world
</blockquote>

## `marco-test-two`
<blockquote>

## [0.4.14](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.4.13...marco-test-two-v0.4.14) - 2024-04-21

### Other
- hi world
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).