### PR TITLE
chore: release

### DIFF
--- a/subdir/Cargo.lock
+++ b/subdir/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "marco-test-one"
-version = "0.3.22"
+version = "0.3.23"
 
 [[package]]
 name = "marco-test-three"
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/subdir/Cargo.toml
+++ b/subdir/Cargo.toml
@@ -6,4 +6,4 @@ members = [
 
 [workspace.dependencies]
 serde = "1.0.164"
-marco-test-one = { path = "crates/marco-test-one", version = "0.3.22" }
+marco-test-one = { path = "crates/marco-test-one", version = "0.3.23" }

--- a/subdir/crates/marco-test-one/CHANGELOG.md
+++ b/subdir/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.23](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.22...marco-test-one-v0.3.23) - 2024-10-15
+
+### Other
+- hi there (by @MarcoIeni) - #227
+
 ## [0.3.22](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.21...marco-test-one-v0.3.22) - 2024-10-12
 
 ### Other

--- a/subdir/crates/marco-test-one/Cargo.toml
+++ b/subdir/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.3.22"
+version = "0.3.23"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/subdir/crates/marco-test-two/CHANGELOG.md
+++ b/subdir/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.5.7...marco-test-two-v0.5.8) - 2024-10-15
+
+### Other
+- updated the following local packages: marco-test-one
+
 ## [0.5.7](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.5.6...marco-test-two-v0.5.7) - 2024-10-12
 
 ### Other

--- a/subdir/crates/marco-test-two/Cargo.toml
+++ b/subdir/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "just a test for release-plz"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `marco-test-one`: 0.3.22 -> 0.3.23 (✓ API compatible changes)
* `marco-test-two`: 0.5.7 -> 0.5.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `marco-test-one`
<blockquote>

## [0.3.23](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.22...marco-test-one-v0.3.23) - 2024-10-15

### Other
- hi there (by @MarcoIeni) - #227
</blockquote>

## `marco-test-two`
<blockquote>

## [0.5.8](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.5.7...marco-test-two-v0.5.8) - 2024-10-15

### Other
- updated the following local packages: marco-test-one
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).