### PR TITLE
chore: release

### DIFF
--- a/subdir/Cargo.lock
+++ b/subdir/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "marco-test-one"
-version = "0.3.25"
+version = "0.4.0"
 
 [[package]]
 name = "marco-test-three"
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "marco-test-two"
-version = "0.5.10"
+version = "0.6.0"
 dependencies = [
  "marco-test-one",
  "tokio",

--- a/subdir/Cargo.toml
+++ b/subdir/Cargo.toml
@@ -6,4 +6,4 @@ members = [
 
 [workspace.dependencies]
 serde = "1.0.164"
-marco-test-one = { path = "crates/marco-test-one", version = "0.3.25" }
+marco-test-one = { path = "crates/marco-test-one", version = "0.4.0" }

--- a/subdir/crates/marco-test-one/CHANGELOG.md
+++ b/subdir/crates/marco-test-one/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.25...marco-test-one-v0.4.0) - 2025-02-09
+
+### Other
+
+- wip
+- wip
+
 ## [0.3.25](https://github.com/marcoieni/rust-workspace-example/compare/marco-test-one-v0.3.24...marco-test-one-v0.3.25) - 2025-02-02
 
 ### Other

--- a/subdir/crates/marco-test-one/Cargo.toml
+++ b/subdir/crates/marco-test-one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-one"
-version = "0.3.25"
+version = "0.4.0"
 edition = "2021"
 description = "marco-test-one"
 license = "MIT OR Apache-2.0"

--- a/subdir/crates/marco-test-one/src/lib.rs
+++ b/subdir/crates/marco-test-one/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn hello() {
+pub fn helo() {
     println!("Hi, world!!!!!!!");
 }
 

--- a/subdir/crates/marco-test-one/src/lib.rs
+++ b/subdir/crates/marco-test-one/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn helo() {
+pub fn hellllllo() {
     println!("Hi, world!!!!!!!");
 }
 

--- a/subdir/crates/marco-test-two/CHANGELOG.md
+++ b/subdir/crates/marco-test-two/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.5.10...marco-test-two-v0.6.0) - 2025-02-09
+
+### Other
+
+- wip
+
 ## [0.5.10](https://github.com/marcoieni/rust-workspace-example/compare/marco-test-two-v0.5.9...marco-test-two-v0.5.10) - 2025-02-02
 
 ### Other

--- a/subdir/crates/marco-test-two/Cargo.toml
+++ b/subdir/crates/marco-test-two/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marco-test-two"
-version = "0.5.10"
+version = "0.6.0"
 edition = "2021"
 description = "just a test for release-plz"
 license = "MIT OR Apache-2.0"

--- a/subdir/crates/marco-test-two/src/lib.rs
+++ b/subdir/crates/marco-test-two/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn hello_breaking_2() {
+pub fn hello_breaking_3() {
     println!("Hello world!!");
 }
 


### PR DESCRIPTION



## 🤖 New release

* `marco-test-one`: 0.3.25 -> 0.4.0 (⚠ API breaking changes)
* `marco-test-two`: 0.5.10 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `marco-test-one` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_missing.ron

Failed in:
  function marco_test_one::hello, previously in file /private/var/folders/cf/zcqg_ct53g3dj0dy81063x500000gn/T/.tmpjUZA59/marco-test-one/src/lib.rs:1
```

### ⚠ `marco-test-two` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_missing.ron

Failed in:
  function marco_test_two::hello_breaking_2, previously in file /private/var/folders/cf/zcqg_ct53g3dj0dy81063x500000gn/T/.tmpjUZA59/marco-test-two/src/lib.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `marco-test-one`

<blockquote>

## [0.4.0](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-one-v0.3.25...marco-test-one-v0.4.0) - 2025-02-09

### Other

- wip
- wip
</blockquote>

## `marco-test-two`

<blockquote>

## [0.6.0](https://github.com/MarcoIeni/rust-workspace-example/compare/marco-test-two-v0.5.10...marco-test-two-v0.6.0) - 2025-02-09

### Other

- wip
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).